### PR TITLE
Allow dynamic function configuration

### DIFF
--- a/include/beamparticle_constants.hrl
+++ b/include/beamparticle_constants.hrl
@@ -101,3 +101,9 @@
 %% key used in process dictionary to define running environment
 %% possible values are prod and stage.
 -define(CALL_ENV_KEY, callenvkey).
+
+%% key used in process dictionary to define last invoked
+%% function configuration as an Erlang map. Notice that
+%% The latest dynamic function which has non undefined
+%% configuration overwrites the previous value.
+-define(CALL_ENV_CONFIG, callenvconfig).

--- a/models/beamparticle_dynamic_function_model.erl
+++ b/models/beamparticle_dynamic_function_model.erl
@@ -133,6 +133,9 @@ get_response(Id, V, #state{qsproplist = QsProplist} = State) when is_binary(Id) 
             T = erlang:monotonic_time(micro_seconds),
             erlang:put(?CALL_TRACE_BASE_TIME, T),
             Result = beamparticle_dynamic:get_result(Id, Arguments),
+            %% as part of dynamic call configurations could be set,
+            %% so lets erase that before the next reuse
+            beamparticle_dynamic:erase_config(),
             CallTrace = erlang:get(?CALL_TRACE_KEY),
             erlang:erase(?CALL_TRACE_KEY),
             CallTraceResp = beamparticle_erlparser:calltrace_to_json_map(CallTrace),
@@ -141,5 +144,8 @@ get_response(Id, V, #state{qsproplist = QsProplist} = State) when is_binary(Id) 
             {jsx:encode([{calltractime_usec, T1 - T}, {calltrace, CallTraceResp} | Result]), State};
         false ->
             Result = beamparticle_dynamic:get_result(Id, Arguments),
+            %% as part of dynamic call configurations could be set,
+            %% so lets erase that before the next reuse
+            beamparticle_dynamic:erase_config(),
             {jsx:encode(Result), State}
     end.

--- a/models/beamparticle_simple_http_post_model.erl
+++ b/models/beamparticle_simple_http_post_model.erl
@@ -121,5 +121,8 @@ get_response(Id, V, #state{qsproplist = QsProplist} = State) when is_binary(Id) 
     ContextBin = jiffy:encode(maps:from_list(QsProplist)),
     Arguments = [V, ContextBin],
     Result = beamparticle_dynamic:get_raw_result(Id, Arguments),
+    %% as part of dynamic call configurations could be set,
+    %% so lets erase that before the next reuse
+    beamparticle_dynamic:erase_config(),
     {Result, State}.
 

--- a/priv/index.html
+++ b/priv/index.html
@@ -159,6 +159,8 @@
 				  tx_text = tx_text + "\n" + get_editor_value()
               } else if (txt.search(/^\.whatis (save|write) /) != -1) {
 				  tx_text = tx_text + "\n" + get_editor_value()
+              } else if (txt.search(/^\.config save /) != -1) {
+				  tx_text = tx_text + "\n" + get_editor_value()
               } else if (txt.search(/^\.runeditor /) != -1) {
 				  tx_text = tx_text + "\n" + get_editor_value()
               } else if (txt.search(/^\.runeditor$/) != -1) {

--- a/src/beamparticle_highperf_http_handler.erl
+++ b/src/beamparticle_highperf_http_handler.erl
@@ -274,6 +274,9 @@ process_http_post(RequestHeaders, RequestBody, RestPath, Data, PartialDataList, 
                            "\"}">>],
             Content = beamparticle_dynamic:get_raw_result(
                         FunctionName, Arguments),
+            %% as part of dynamic call configurations could be set,
+            %% so lets erase that before the next reuse
+            beamparticle_dynamic:erase_config(),
             case is_keepalive(LowerRequestHeaders) of
                 false ->
                     %%send_http_response(Socket, Transport, Content, close),

--- a/src/beamparticle_java_server.erl
+++ b/src/beamparticle_java_server.erl
@@ -566,7 +566,8 @@ load_all_java_functions(JavaServerNodeName) ->
                      <<FunctionPrefix:FunctionPrefixLen/binary, _/binary>> = ExtractedKey ->
                          try
                              case beamparticle_erlparser:detect_language(V) of
-                                 {java, Code, _} ->
+                                 {java, Code, _Config, _} ->
+                                     %% TODO pass config to javanode
                                      Fname = ExtractedKey,
                                      Message = {'com.beamparticle.JavaLambdaStringEngine',
                                                 'load',

--- a/src/beamparticle_javaparser.erl
+++ b/src/beamparticle_javaparser.erl
@@ -21,7 +21,7 @@
 -include("beamparticle_constants.hrl").
 
 -export([
-    evaluate_java_expression/3,
+    evaluate_java_expression/4,
     get_erlang_parsed_expressions/1,
     validate_java_function/2
 ]).
@@ -49,11 +49,13 @@
 %%     }
 %% }
 %% '''
--spec evaluate_java_expression(binary() | undefined, string() | binary(), [term()]) -> any().
-evaluate_java_expression(FunctionNameBin, JavaExpression, Arguments) when is_list(JavaExpression) ->
+-spec evaluate_java_expression(binary() | undefined, string() | binary(),
+                              string() | binary(), [term()]) -> any().
+evaluate_java_expression(FunctionNameBin, JavaExpression, Config, Arguments) when is_list(JavaExpression) ->
     JavaExpressionBin = list_to_binary(JavaExpression),
-    evaluate_java_expression(FunctionNameBin, JavaExpressionBin, Arguments);
-evaluate_java_expression(undefined, JavaExpressionBin, []) ->
+    evaluate_java_expression(FunctionNameBin, JavaExpressionBin, Config, Arguments);
+evaluate_java_expression(undefined, JavaExpressionBin, _Config, []) ->
+    %% TODO use Config
     lager:debug("FunctionNameBin = ~p, JavaExpressionBin = ~p, Arguments = ~p",
                 [undefined, JavaExpressionBin, []]),
     try
@@ -68,7 +70,8 @@ evaluate_java_expression(undefined, JavaExpressionBin, []) ->
                         [C, E, erlang:get_stacktrace()]),
             {error, {exception, {C, E}}}
     end;
-evaluate_java_expression(FunctionNameBin, JavaExpressionBin, Arguments) when is_list(Arguments) ->
+evaluate_java_expression(FunctionNameBin, JavaExpressionBin, _Config, Arguments) when is_list(Arguments) ->
+    %% TODO use Config
     lager:debug("FunctionNameBin = ~p, JavaExpressionBin = ~p, Arguments = ~p",
                 [FunctionNameBin, JavaExpressionBin, Arguments]),
     try

--- a/src/beamparticle_phpparser.erl
+++ b/src/beamparticle_phpparser.erl
@@ -23,7 +23,7 @@
 -include_lib("ephp/include/ephp.hrl").
 
 -export([
-    evaluate_php_expression/2,
+    evaluate_php_expression/3,
     get_erlang_parsed_expressions/1,
     validate_php_function/1,
     convert_erlang_to_php_value/1,
@@ -54,8 +54,9 @@
 %% }
 %% ?>
 %% '''
--spec evaluate_php_expression(string() | binary(), [term()]) -> any().
-evaluate_php_expression(PhpExpression, Arguments) when is_list(Arguments) ->
+-spec evaluate_php_expression(string() | binary(), string() | binary(), [term()]) -> any().
+evaluate_php_expression(PhpExpression, _Config, Arguments) when is_list(Arguments) ->
+    %% TODO use Config
     PhpExpressionStr = case is_binary(PhpExpression) of
                              true ->
                                  binary_to_list(PhpExpression);


### PR DESCRIPTION
NOTE: Java and PHP functions will not use configuration
at present.

In Erlang (likewise in Elixir and Efene) you can get
function configuration via call to
beamparticle_dynamic:get_config/0 function.

    #!erlang
    fun (Body, Context) ->
        DecodedMap = jiffy:decode(Body, [return_maps]),
        Config = beamparticle_dynamic:get_config(),
        Result = DecodedMap#{<<"config">> => Config},
        jiffy:encode(Result)
    end.

For Elixir:

    #!elixir
    fn (body, context) ->
        decoded_map = :jiffy.decode(body, [:return_maps])
        config = :beamparticle_dynamic.get_config()
        # TODO process decoded_map
        result = %{decoded_map | "config": config}
        :jiffy.encode(result)
    end

In python, you can get configuration via _get_config() call.
This magic function shall return a python dictionary, which
is deserialized from json configuration.

Sample python dynamic function, which uses the configuration.

    #!python

    import sys
    import json

    from Pyrlang import term

    def main(post_binary, context_binary):
        data = data_binary.decode('utf-8')
        context = context_binary.decode('utf-8')
        result = handle_event(data, context)
        return term.Binary(result.encode('utf-8'))

    def handle_event(data, context):
        try:
            json_value = json.loads(data)
            json_value['config'] = _get_config()
            return json.dumps(json_value)
        except Exception as e:
            return str(e)